### PR TITLE
Added db_user argument to db2server command and Python 2 & 3 compatibility fixes

### DIFF
--- a/cathub/__init__.py
+++ b/cathub/__init__.py
@@ -14,7 +14,7 @@ def cli():
 @click.option('--goto-reaction', help="""name of reaction folder to skip to""")
 def folder2db(folder_name, debug, skip_folders, goto_reaction):
     import os
-    import folder2db
+    import cathub.folder2db
 
     skip = []
     for s in skip_folders.split(', '):
@@ -32,16 +32,19 @@ def folder2db(folder_name, debug, skip_folders, goto_reaction):
 @click.option('--write_publication', default=True, type=bool)
 @click.option('--block-size', default=1000, type=int)
 @click.option('--start-block', default=0, type=int)
+@click.option('--db_user', default='catroot', type=str)
 def db2server(dbfile, start_id, write_reaction, write_ase, write_publication,
-              write_reaction_system, block_size, start_block):
+              write_reaction_system, block_size, start_block, db_user):
     import os
-    import db2server
+    import cathub.db2server
     db2server.main(dbfile, start_id=start_id, write_reaction=write_reaction,
                    write_ase=write_ase,
                    write_publication=write_publication,
                    write_reaction_system=write_reaction_system,
                    block_size=block_size,
-                   start_block=start_block)
+                   start_block=start_block,
+                   db_user=db_user,
+                   )
 
 
 reaction_columns = ['chemicalComposition', 'surfaceComposition',
@@ -60,7 +63,7 @@ publication_columns = ['pubId', 'title', 'authors', 'journal', 'year', 'doi', 't
               help="Make a selection on one of the columns: {0}\n Examples: \n -q chemicalComposition=~Pt for surfaces containing Pt \n -q reactants=CO for reactions with CO as a reactants".format(reaction_columns))
 # Keep {0} in string.format for python2.6 compatibility
 def reactions(columns, n_results, queries):
-    import query
+    import cathub.query
     if not isinstance(queries, dict):
         query_dict = {}
         for q in queries:
@@ -79,7 +82,7 @@ def reactions(columns, n_results, queries):
     query.main(table='reactions', columns=columns, n_results=n_results, queries=query_dict)
 
 
-    
+
 @cli.command()
 @click.option('--columns', '-c',
               default = ('title', 'authors', 'journal', 'year'),
@@ -90,7 +93,7 @@ def reactions(columns, n_results, queries):
               help="Make a selection on one of the columns: {0}\n Examples: \n -q: \n title=~Evolution \n authors=~bajdich \n year=2017".format(publication_columns))
               # Keep {0} in string.format for python2.6 compatibility
 def publications(columns, n_results, queries):
-    import query
+    import cathub.query
     if not isinstance(queries, dict):
         query_dict = {}
         for q in queries:
@@ -105,11 +108,11 @@ def publications(columns, n_results, queries):
             except:
                 query_dict.update({key: '{0}'.format(value)})
                 # Keep {0} in string.format for python2.6 compatibility
-    
+
     query.main(table='publications', columns=columns, n_results=n_results, queries=query_dict)
 
 
-    
+
 @cli.command()
 @click.argument('template')
 @click.option('--create-template', is_flag=True, help="Create an empty template file.")
@@ -122,23 +125,23 @@ def make_folders(create_template, template, custom_base, diagnose):
 
     Use this command make the right structure for your folders
     for submitting data for Catalysis Hub.
-    
+
     Start by creating a template file by calling:
-    
+
     $ cathub make_folders --create-template <template_name>
 
     Then open the template and modify it to so that it contains the information
     for you data. You will need to enter publication/dataset information,
-    and specify the types of surfaces, facets and reactions. 
+    and specify the types of surfaces, facets and reactions.
 
-    The 'reactions' key is a list of dictionaries. 
-    A new dictionary is required for each reaction, and should include two 
-    lists, 'reactants' and 'products'. Remember to balance the equation and 
+    The 'reactions' key is a list of dictionaries.
+    A new dictionary is required for each reaction, and should include two
+    lists, 'reactants' and 'products'. Remember to balance the equation and
     include a minus sign in the name when relevant.
 
     'reactions': [
         {
-          'reactants': ['CCH3star@ontop'], 
+          'reactants': ['CCH3star@ontop'],
           'products': ['Cstar@hollow', 'CH3star@ontop']
         },
         {
@@ -155,16 +158,16 @@ def make_folders(create_template, template, custom_base, diagnose):
       '@site' (i.e. OHstar in bridge-> OHstar@bridge)
 
     Then, save the template and call:
-    
+
     $ cathub make_folders <template_name>
 
-    And folders will be created automatically. 
+    And folders will be created automatically.
 
     You can create several templates and call make_folders again
-    if you, for example, are using different functionals or are 
+    if you, for example, are using different functionals or are
     doing different reactions on different surfaces.
     """
-    import make_folders_template
+    import cathub.make_folders_template
     import json
     import os
 
@@ -184,7 +187,7 @@ def make_folders(create_template, template, custom_base, diagnose):
         'DFT_code': 'Quantum Espresso',
         'DFT_functional': 'BEEF-vdW',
         'reactions': [
-                {'reactants': ['2.0H2Ogas', '-1.5H2gas', 'star'], 
+                {'reactants': ['2.0H2Ogas', '-1.5H2gas', 'star'],
                  'products': [ 'OOHstar@top']},
                 {'reactants': ['CCH3star@bridge'], 'products': ['Cstar@hollow', 'CH3star@ontop']},
                 {'reactants': ['CH4gas', '-0.5H2gas', 'star'], 'products': ['CH3star@ontop']}
@@ -246,7 +249,7 @@ def make_folders(create_template, template, custom_base, diagnose):
 @cli.command()
 def psql_server_connect():
     """Test connection to PostreSQL server."""
-    import psql_server_connect
+    import cathub.psql_server_connect
 
 
 @cli.command()
@@ -261,4 +264,4 @@ def psql_server_connect():
 @click.argument('final_level')
 def write_user_spec():
     """Write JSON specfile for single DFT calculation."""
-    import write_user_spec
+    import cathub.write_user_spec

--- a/cathub/ase_tools.py
+++ b/cathub/ase_tools.py
@@ -120,7 +120,7 @@ def get_formula_from_numbers(numbers):
 def get_numbers_from_formula(formula):
     atoms = Atoms(formula)
     return get_atomic_numbers(atoms)
-    
+
 
 def clear_state(name):
     name = name.replace('*', '').replace('(g)', '')
@@ -183,14 +183,15 @@ def get_state(name):
     return state
 
 
-def get_reaction_energy(traj_files, reaction, reaction_atoms, states, 
+def get_reaction_energy(traj_files, reaction, reaction_atoms, states,
                         prefactors, prefactors_TS, energy_corrections):
 
     energies = {}
     for key in traj_files.keys():
         energies.update({key: ['' for n in range(len(traj_files[key]))]})
-    for key, trajlist in traj_files.iteritems():
-        for i, traj in enumerate(trajlist):            
+    for key, trajlist in traj_files.items():
+        # in python3 iteritems goes away in favor of items
+        for i, traj in enumerate(trajlist):
             try:
                 trajname =  clear_prefactor(reaction[key][i])
             except:
@@ -201,7 +202,7 @@ def get_reaction_energy(traj_files, reaction, reaction_atoms, states,
                 Ecor = 0
             energies[key][i] = prefactors[key][i] * (get_energy(traj) + Ecor)
 
-    # Reaction energy:        
+    # Reaction energy:
     energy_reactants = np.sum(energies['reactants'])
     energy_products = np.sum(energies['products'])
 
@@ -209,7 +210,7 @@ def get_reaction_energy(traj_files, reaction, reaction_atoms, states,
 
     # Activation energy
     if 'TS' in traj_files.keys():
-        # Is a different empty surface used for the TS? 
+        # Is a different empty surface used for the TS?
         if 'TSempty' in traj_files.keys():
             for key in reaction_atoms.keys():
                 if '' in  reaction_atoms[key]:
@@ -218,7 +219,7 @@ def get_reaction_energy(traj_files, reaction, reaction_atoms, states,
             traj_tsempty =  traj_files['TSempty'][0]
             # print(traj_tsempty, traj_empty)
             tsemptydiff = get_energy(traj_tsempty) - get_energy(traj_empty)
-        
+
         for i, traj in enumerate(traj_files['reactants']):
             try:
                 trajname =  clear_prefactor(reaction['reactants'][i])
@@ -233,7 +234,7 @@ def get_reaction_energy(traj_files, reaction, reaction_atoms, states,
             if 'TSempty' in traj_files.keys() and \
                     states['reactants'][i] == 'star':
                 energies['reactants'][i] += prefactors_TS['reactants'][i]\
-                    * tsemptydiff     
+                    * tsemptydiff
         energy_reactants = np.sum(energies['reactants'])
         energy_TS = energies['TS'][0]
         activation_energy = energy_TS - energy_reactants
@@ -444,20 +445,20 @@ def get_reaction_from_folder(folder_name):
                          'products': products})
     else:
         raise AssertionError('problem with folder {}'.format(folder_name))
-    
-    for key, mollist in reaction.iteritems():
+
+    for key, mollist in reaction.items():
         for n, mol in enumerate(mollist):
             if 'gas' not in mol and 'star' not in mol:
                 reaction[key][n] = mol + 'star'
 
 
-    for key, mollist in reaction.iteritems():
+    for key, mollist in reaction.items():
         n_star = mollist.count('star')
         if n_star > 1:
             for n in range(n_star):
                 mollist.remove('star')
             mollist.append(str(n_star) + 'star')
-    
+
     #from tools import check_reaction
     #check_reaction(reaction['reactants'], reaction['products'])
     return reaction
@@ -473,7 +474,7 @@ def get_reaction_atoms(reaction):
     states = {'reactants': [],
               'products': []}
 
-    for key, mollist in reaction.iteritems():
+    for key, mollist in reaction.items():
         for molecule in mollist:
             atoms, prefactor = get_atoms(molecule)
             reaction_atoms[key].append(atoms)
@@ -488,7 +489,7 @@ def get_reaction_atoms(reaction):
     n_star = {'reactants': 0,
               'products': 0}
 
-    for key, statelist in states.iteritems():
+    for key, statelist in states.items():
         for j, s in enumerate(statelist):
             if s == 'star':
                 n_star[key] += prefactors[key][j]
@@ -499,13 +500,13 @@ def get_reaction_atoms(reaction):
     diff = n_p - n_r
     if abs(diff) > 0:
         if diff > 0:  # add empty slabs to left-hand side
-            n_r += diff 
+            n_r += diff
             key = 'reactants'
         else:  # add to right-hand side
             diff *= -1  # diff should be positive
             n_p += diff
             key = 'products'
-        
+
         if '' not in reaction_atoms[key]:
             reaction[key].append('star')
             prefactors[key].append(diff)
@@ -517,7 +518,7 @@ def get_reaction_atoms(reaction):
             index = states[key].index('star')
             prefactors[key][index] += diff
             # if key == 'reactants':
-            #     prefactors_TS[key]['star'] += 1  
+            #     prefactors_TS[key]['star'] += 1
 
     if n_r > 1: # Balance slabs for transition state
         count_empty = 0
@@ -529,7 +530,7 @@ def get_reaction_atoms(reaction):
             reaction_atoms['reactants'].append('')
             prefactors['reactants'].append(0)
             states['reactants'].append('star')
-            prefactors_TS['reactants'].append(-n_r + 1)            
+            prefactors_TS['reactants'].append(-n_r + 1)
     else:
         if '' in reaction_atoms['reactants']:
             index = reaction_atoms['reactants'].index('')
@@ -547,6 +548,6 @@ def debug_assert(expression, message, debug=False):
             return False
     else:
         assert expression, message
-    
+
     return True
 # def handle_gas_species():

--- a/cathub/create_user.py
+++ b/cathub/create_user.py
@@ -3,7 +3,7 @@ from postgresql import CathubPostgreSQL
 import os
 
 def main(user):
-    db = CathubPostgreSQL(password=os.environ['DB_PASSWORD0'])  
+    db = CathubPostgreSQL(password=os.environ['DB_PASSWORD0'])
     db.create_user(user)
 
 if __name__ == '__main__':

--- a/cathub/db2server.py
+++ b/cathub/db2server.py
@@ -1,11 +1,14 @@
 from sys import argv
-from postgresql import CathubPostgreSQL
+from cathub.postgresql import CathubPostgreSQL
 
-def main(dbfile, start_id=1, write_reaction=True, write_ase=True, 
+def main(dbfile, start_id=1, write_reaction=True, write_ase=True,
          write_publication=True, write_reaction_system=True,
-         block_size=1000, start_block=0):
+         block_size=1000, start_block=0,
+         db_user='catroot',
+         db_password=None,
+         ):
 
-    db = CathubPostgreSQL()
+    db = CathubPostgreSQL(user=db_user, password=db_password)
     db.transfer(dbfile, start_id=start_id, write_reaction=write_reaction,
                 write_ase=write_ase,
                 write_publication=write_publication,

--- a/cathub/folder2db.py
+++ b/cathub/folder2db.py
@@ -1,6 +1,6 @@
 import os
 from sys import argv
-from folderreader import FolderReader
+from cathub.folderreader import FolderReader
 
 def main(folder_name, debug=False, skip=[], goto_reaction=None):
     FR = FolderReader(folder_name=folder_name, debug=debug)

--- a/cathub/folder_check.py
+++ b/cathub/folder_check.py
@@ -26,14 +26,14 @@ def main(folder):
                     os.remove(root + '/' + file)
                 else:
                     miss_list.append(traj)
-    
+
     if len(miss_list) > 0:
         print('Files missing')
         print(miss_list)
     else:
         print('all files there!')
-    return 
-    
+    return
+
 if __name__ == "__main__":
     from sys import argv
     folder = argv[1]

--- a/cathub/folderreader.py
+++ b/cathub/folderreader.py
@@ -4,9 +4,9 @@ import copy
 import sqlite3
 from sys import argv
 import json
-from ase_tools import *
-from cathubsqlite import CathubSQLite
-from tools import get_bases
+from cathub.ase_tools import *
+from cathub.cathubsqlite import CathubSQLite
+from cathub.tools import get_bases
 import glob
 from ase.io.trajectory import convert
 import ase
@@ -176,7 +176,7 @@ class FolderReader:
                 print('ERROR: No tags')
                 self.tags = None
 
-            for key, value in pub_data.iteritems():
+            for key, value in pub_data.items():
                 if isinstance(value, list):
                     value = json.dumps(value)
                 else:
@@ -283,7 +283,7 @@ class FolderReader:
 
             id, ase_id = check_in_ase(traj, self.cathub_db) #self.ase_db)
 
-            for key, mollist in self.reaction_atoms.iteritems():
+            for key, mollist in self.reaction_atoms.items():
                 for i, molecule in enumerate(mollist):
                     if molecule == chemical_composition \
                             and self.states[key][i] == 'gas':
@@ -415,7 +415,7 @@ class FolderReader:
         #    activation_energy = None
 
         prefactor_scale = copy.deepcopy(self.prefactors)
-        for key1, values in prefactor_scale.iteritems():
+        for key1, values in prefactor_scale.items():
             prefactor_scale[key1] = [1 for v in values]
 
         #prefactor_scale_ads = copy.deepcopy(prefactor_scale)
@@ -464,7 +464,7 @@ class FolderReader:
 
             elif i == empty_i:
                 found = True
-                for key, mollist in self.reaction_atoms.iteritems():
+                for key, mollist in self.reaction_atoms.items():
                     if '' in mollist:
                         n = mollist.index('')
                         self.traj_files[key][n] = traj
@@ -489,7 +489,7 @@ class FolderReader:
 
             supercell_factor = 1
             n_ads = 1
-            for key, mollist in self.reaction_atoms.iteritems():
+            for key, mollist in self.reaction_atoms.items():
                 if found:
                     continue
                 for n, molecule in enumerate(mollist):
@@ -536,14 +536,14 @@ class FolderReader:
 
 
             if n_ads > 1:
-                for key1, values in prefactor_scale.iteritems():
+                for key1, values in prefactor_scale.items():
                     for mol_i in range(len(values)):
                         #prefactor_scale_ads[key1][mol_i] = n_ads
                         if self.states[key1][mol_i] == 'gas':
                             prefactor_scale[key1][mol_i] = n_ads
 
             if supercell_factor > 1:
-                for key2, values in prefactor_scale.iteritems():
+                for key2, values in prefactor_scale.items():
                     for mol_i in range(len(values)):
                         if self.reaction[key2][mol_i] =='star':
                             prefactor_scale[key2][mol_i] *= supercell_factor + 1

--- a/cathub/make_folders_template.py
+++ b/cathub/make_folders_template.py
@@ -37,7 +37,7 @@ def main(
     #  ---------reaction info-----------
 
     reactions=[
-        {'reactants': ['2.0H2Ogas', '-1.5H2gas', 'star'], 
+        {'reactants': ['2.0H2Ogas', '-1.5H2gas', 'star'],
          'products': ['OOHstar@ontop']},
         #{'reactants': ['CCH3'], 'products': ['C', 'CH3']},
         #{'reactants': ['CH3star'], 'products': ['CH3gas', 'star']}
@@ -71,8 +71,8 @@ def main(
     In case of adsorbed species, include the site after 'star' as f.ex
     star@top, star@bridge.
 
-    Remember to include the reactions that gives the adsorption energy of 
-    reaction intermediates, taking gas phase molecules as references 
+    Remember to include the reactions that gives the adsorption energy of
+    reaction intermediates, taking gas phase molecules as references
     (preferably H20, H2, CH4, CO, NH3).
 
     For example, we can write the adsorption of CH2 as:
@@ -86,10 +86,10 @@ def main(
         {'reactants': ['CH4gas', '-H2gas', 'star'], 'products': ['CH2star@bridge']},
         {'reactants': ['CH4gas', '-0.5H2gas', 'star'], 'products': ['CH3star@top']}
         ]
-    
+
     A new dictionary is required for each reaction, and should include two lists,
-    'reactants' and 'products'. Remember to include a minus sign and prefactor in 
-    the name when relevant. If your reaction is not balanced, you will 
+    'reactants' and 'products'. Remember to include a minus sign and prefactor in
+    the name when relevant. If your reaction is not balanced, you will
     receive an error when running the script.
 
     # ---------------surface info---------------------
@@ -141,7 +141,7 @@ def main(
         energy_txt = publication_base + 'energy_corrections.txt'
         json.dump(energy_corrections, open(energy_txt, 'wb'))
 
-    
+
     def create(path):
         if not os.path.exists(path):
             os.mkdir(path)
@@ -155,13 +155,13 @@ def main(
     ads_names = []
     from ase_tools import get_state, clear_state, clear_prefactor
     for i in range(len(reactions)):
-        rnames = [r.split('@')[0] for r in reactions[i]['reactants'] + 
+        rnames = [r.split('@')[0] for r in reactions[i]['reactants'] +
                   reactions[i]['products']]
-        states = [get_state(r) for r in rnames]        
+        states = [get_state(r) for r in rnames]
         gas_names += [clear_state(clear_prefactor(rnames[i]))
                       for i in range(len(states)) if states[i] == 'gas']
 
-        
+
     for name in set(gas_names):
         with open(gas_base + 'MISSING: {}_gas.traj'.format(name), 'w'):
             pass
@@ -182,12 +182,12 @@ def main(
                     rname = '_'.join(reactions[i]['reactants'])
                     pname = '_'.join(reactions[i]['products'])
                     reaction_name = '__'.join([rname, pname])
-                    base = create(reaction_base + reaction_name + '/')      
-                    rnames = [r.split('@')[0] for r in reactions[i]['reactants'] + 
+                    base = create(reaction_base + reaction_name + '/')
+                    rnames = [r.split('@')[0] for r in reactions[i]['reactants'] +
                               reactions[i]['products']]
                     states = [get_state(r) for r in rnames]
-        
-                    ads_names = [clear_prefactor(clear_state(rnames[i])) 
+
+                    ads_names = [clear_prefactor(clear_state(rnames[i]))
                                  for i in range(len(states)) if states[i] == 'star']
 
                     for ads in ads_names:

--- a/cathub/psql_server_connect.py
+++ b/cathub/psql_server_connect.py
@@ -3,4 +3,4 @@ from sys import argv
 
 user = argv[1]
 
-os.system('psql --host=catalysishub.c8gwuc8jwb7l.us-west-2.rds.amazonaws.com --port=5432 --username={} --dbname=catalysishub --password'.format(user))
+os.system('psql --host=catalysishub.c8gwuc8jwb7l.us-west-2.rds.amazonaws.com --port=5432 --username={0} --dbname=catalysishub --password'.format(user))

--- a/cathub/query.py
+++ b/cathub/query.py
@@ -8,7 +8,7 @@ def main(table, columns, n_results, queries):
                           columns=columns,
                           n_results=n_results,
                           queries=queries)
-    
+
     execute(query)
 
 
@@ -55,7 +55,7 @@ def graphql_query(table='reactions',
     statement += '    }\n'
     statement += '  }\n'
     statement += '}}'
-    
+
     return  statement
 
 
@@ -66,5 +66,5 @@ if __name__ == '__main__':
                           'products'],
                  n_results=10,
                  queries={'chemicalComposition': "~Pt"})
-    
+
 

--- a/cathub/tools.py
+++ b/cathub/tools.py
@@ -58,7 +58,7 @@ def add_atoms(atoms_list):
 
 def check_reaction(reactants, products):
     """
-    check the stoichiometry and format of chemical reaction used for 
+    check the stoichiometry and format of chemical reaction used for
     folder structure.
     list of reactants -> list of products
     """
@@ -96,7 +96,7 @@ def get_bases(folder_name):
         elif sherlock == '2':
             catbase = '/home/users/winther/data_catapp/'
 
-    elif 'SLAC_ENVIRON' in os.environ:        
+    elif 'SLAC_ENVIRON' in os.environ:
         catbase = '/nfs/slac/g/suncatfs/data_catapp/'
     else:
         catbase = './'
@@ -112,4 +112,4 @@ def get_bases(folder_name):
 
 
     return catbase, data_base, user, user_base
-    
+

--- a/cathub/write_user_spec.py
+++ b/cathub/write_user_spec.py
@@ -1,6 +1,6 @@
 import json
 from sys import argv
-import os 
+import os
 
 try:  #sherlock 1 or 2
     sherlock = os.environ['SHERLOCK']
@@ -29,8 +29,8 @@ user_dict = {'user': user,
              'site_level': site,
              'final_level': int(final)
              }
-    
-user_file = '{}winther/user_specific/{}.txt'.format(catbase, user) 
+
+user_file = '{0}winther/user_specific/{1}.txt'.format(catbase, user)
 json.dump(user_dict, open(user_file, 'w'))
 
 


### PR DESCRIPTION
Python 2 &3 compatibility requires:
- `list.iteritems()` -> `list.items()`
- all relative imports are best replaced by absolute imports. Good thing we can `import cathub`
- this is actually a downward python 2.6 compatibility thing: '{0} {1}'.format(...) instead of '{} {}'.format(...) requires the index of the interpolation.